### PR TITLE
Correction for cell_IDs

### DIFF
--- a/NS_protein_covariation/EMT_1_imputed_data.m
+++ b/NS_protein_covariation/EMT_1_imputed_data.m
@@ -5,7 +5,7 @@
 Path = [path 'Collaborators/EmiliLab/EMT.TGFB_scProt_1/001-SCPipeline_Output/'];
 
 [dat, txt] = xlsread( [Path 'EpiToMesen.TGFB.nPoP_trial1_1PercFDR.xlsx']);
-Cell_Ids = txt(1,2:end);
+Cell_Ids = txt(1,1:end);
 ProtIDs = txt(2:end,1);
 
 [~, IDs] = xlsread( [Path 'cellIDToTimepoint.xlsx']);

--- a/NS_protein_covariation/EMT_2.m
+++ b/NS_protein_covariation/EMT_2.m
@@ -7,7 +7,7 @@
 Path = [path 'Collaborators/EmiliLab/EMT.TGFB_scProt_1/001-SCPipeline_Output/'];
 
 [dat_L, txt] = xlsread( [Path 'EpiToMesen.TGFB.nPoP_trial1_1PercDartFDRTMTBulkDIA.WallE_unimputed.xlsx']);
-Cell_Ids = txt(1,2:end);
+Cell_Ids = txt(1,1:end);
 ProtIDs_L = txt(2:end,1);
 
 [~, IDs] = xlsread( [Path 'cellIDToTimepoint.xlsx']);

--- a/NS_protein_covariation/EMT_4.m
+++ b/NS_protein_covariation/EMT_4.m
@@ -8,7 +8,7 @@
 Path = [path 'Collaborators/EmiliLab/EMT.TGFB_scProt_1/001-SCPipeline_Output/'];
 
 [dat_L, txt] = xlsread( [Path 'EpiToMesen.TGFB.nPoP_trial1_1PercDartFDRTMTBulkDIA.WallE_unimputed.xlsx']);
-Cell_Ids = txt(1,2:end);
+Cell_Ids = txt(1,1:end);
 ProtIDs_L = txt(2:end,1);
 
 [~, IDs] = xlsread( [Path 'cellIDToTimepoint.xlsx']);


### PR DESCRIPTION
Thank you for sharing all the information. I was able to reproduce the exact results using your Matlab scripts but couldn't reproduce them in my R implementation. I noticed a mistake in your scripts:

Cell_Ids = txt(1,2:end);

The Cell_Ids are shifted, which affects the subsetting by conditions (d0, d3, and d9). The resulting clusters are quite different after correcting this mistake. I observed 2 distinct clusters instead of 3 and memberships are different with the ARI index (~0.25). 

Correction:
Cell_Ids = txt(1,**1**:end);


Best regards,
Enes
@nslavov 